### PR TITLE
[FEATURE] Give the sentry client access to the TYPO3 logger

### DIFF
--- a/Classes/Service/SentryService.php
+++ b/Classes/Service/SentryService.php
@@ -4,6 +4,8 @@ namespace Jops\TYPO3\Sentry\Service;
 
 use Sentry\ClientBuilder;
 use Sentry\SentrySdk;
+use TYPO3\CMS\Core\Log\LogManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class SentryService
 {
@@ -18,6 +20,13 @@ class SentryService
 			"release" => ConfigurationService::getRelease(),
 			"environment" => ConfigurationService::getEnvironment()
 		]);
+
+		// We need to use the GeneralUtility to instantiate a LogManager, because we can't use either
+		// DependencyInjection or the LoggerAwareTrait.
+		$clientBuilder->setLogger(
+			GeneralUtility::makeInstance(LogManager::class)
+				->getLogger("Sentry-Client") // TODO: The name of the logger should be configurable
+		);
 
 		SentrySdk::init()->bindClient($clientBuilder->getClient());
 	}


### PR DESCRIPTION
Call `->setLogger()` on the `ClientBuilder` and pass an instance of the TYPO3 `LogManager`.
This passes all errors that might occur in the Sentry Client to the TYPO3 logging system. 

Fixes: #8 