### PR TITLE
fix: proper load environment variables into configuration

### DIFF
--- a/Classes/Domain/Configuration/Configuration.php
+++ b/Classes/Domain/Configuration/Configuration.php
@@ -9,17 +9,34 @@ class Configuration
 {
     protected ExtensionConfiguration $extensionConfiguration;
 
+    protected bool $active = false;
+    protected string $dsn = "";
+    protected string $environment = "Production";
+    protected string $release = "1.0.0";
+    protected float $traces_sample_rate = 0.0;
+
+    /**
+     * Configuration constructor.
+     *
+     * Builds the Configuration classes and respects priority for different configuration sources.
+     * Configuration gets loaded from. (Lower overwrites higher)
+     *   1. Environment Variables
+     *   2. TYPO3 Extension configuration
+     *
+     * @param ExtensionConfiguration $extensionConfiguration
+     */
     public function __construct(
         ExtensionConfiguration $extensionConfiguration
     ) {
         $this->extensionConfiguration = $extensionConfiguration;
+        $this->populateWithEnvironmentVariables();
 
         try {
             /** @var array<string> $configuration */
             $configuration = $this->extensionConfiguration->get("typo3_sentry_client");
 
             foreach ($configuration as $key => $value) {
-                if (property_exists(__CLASS__, $key)) {
+                if (property_exists(__CLASS__, $key) && $value !== "") {
                     $this->$key = $value;
                 }
             }
@@ -28,11 +45,29 @@ class Configuration
         }
     }
 
-    protected bool $active = false;
-    protected string $dsn = "";
-    protected string $environment = "Production";
-    protected string $release = "1.0.0";
-    protected float $traces_sample_rate = 0.0;
+    /**
+     * Populate $this with configuration from environment variables.
+     * If the environment variable is not set, the property does not get set and remains at the default value.
+     *
+     * @return void
+     */
+    private function populateWithEnvironmentVariables(): void
+    {
+        $envMapping = [
+            ["active", "SENTRY_ACTIVE"],
+            ["dsn", "SENTRY_DSN"],
+            ["environment", "SENTRY_ENVIRONMENT"],
+            ["release", "SENTRY_RELEASE"],
+            ["traces_sample_rate", "SENTRY_TRACES_SAMPLE_RATE"],
+        ];
+
+        foreach ($envMapping as $conf) {
+            $value = getenv($conf[1]);
+            if ($value) {
+                $this->$conf[0] = $value;
+            }
+        }
+    }
 
     /**
      * @return ExtensionConfiguration


### PR DESCRIPTION
This PR updates the `Configuration` class to proper load environment variables.
Environment variables get loaded before TYPO3 extension configuration and therefore can be overwritten by them.

Fixes #41 